### PR TITLE
Add quotes around lines containing commas

### DIFF
--- a/app/public/csv/suffixes.csv
+++ b/app/public/csv/suffixes.csv
@@ -34,7 +34,7 @@ dedicate your life to the Sun God.
 ensure your ghost will haunt your worst enemy after you die.
 awaken the Elder Gods.
 protect your family from criminals using the power of stem cells.
-talk your way out of being hung, drawn and quartered.
+"talk your way out of being hung, drawn and quartered."
 achieve global hegemony.
 write a Five Year Plan that actually works.
 re-militarise the Rhineland.
@@ -102,7 +102,7 @@ use Shamir's Secret Sharing to bind your soul to horcruxes.
 perpetuate an urban myth.
 scare off potential burgulars by openly practicing Mesoamerican Polytheism.
 make ill-informed decisions even after carefully weighing the options.
-thaw your cold, cold heart.
+"thaw your cold, cold heart."
 transubstantiate an ice-cold glass of Coca Cola.
 get that incredibly annoying song out of your head for five minutes so you can think straight.
 convincingly feign drunkeness.


### PR DESCRIPTION
Currently a response could be `{title: "Here's our 29 favourite tricks to thaw your cold cold heart."}` but you have a comma on that line which in CSV creates a new column. Surrounding the text with a quote keeps the line one column so the response will contain the comma again.

Really cool project BTW!